### PR TITLE
fix(github-actions): error to get archlinux/base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/base
+FROM archlinux
 # Arch tracks changes in their package manager at the same rate as brew on mac does or at least is very close
 
 # This should be arch to get on latest


### PR DESCRIPTION
archlinux/base was removed from dockerhub