### PR TITLE
Using tfswitch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,11 @@ FROM archlinux
 RUN pacman -Syu --noconfirm aws-cli grep git awk unzip kubectl jq yq curl && \
     rm -rf /var/cache/pacman/
 
-# Download latest terraform zip
-# RUN VERSION_REGEX='terraform_[0-9]\.[0-9]{1,2}\.[0-9]{1,2}_linux.*amd64' && \
-#     TF_RELEASES="https://releases.hashicorp.com/terraform/index.json" && \
-#     LATEST=$(curl -s $TF_RELEASES | jq -r '.versions[].builds[].url' | egrep $VERSION_REGEX | sort -V | tail -1) && \
-#     curl -sL $LATEST -o terraform.zip
+# Installing tfswitch
+RUN curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
 
-#############################################################################
-# TEMPORARILY HARD CODING TERRAFORM VERSION UNTIL PROPER UPGRADE CAN HAPPEN #
-#############################################################################
-RUN curl -sL https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -o terraform.zip
-
-# Unzip terraform release and move to bin path
-RUN unzip terraform.zip && rm terraform.zip && \
-    chmod 755 /terraform && \
-    mv /terraform /usr/bin/terraform
+# Installing latest stable versions of 0.11, 0.12, 0.13, 0.14, 0.15, 1.0
+RUN tfswitch -s 0.11; tfswitch -s 0.12; tfswitch -s 0.13; tfswitch -s 0.14; tfswitch -s 0.15; tfswitch -s 1.0
 
 # check the version on output for visibility as to what was installed
 RUN terraform version


### PR DESCRIPTION
**What**
Dockerfile using tfswitch instead of terraform static versions

**Why**
To give flexibility to the code with different terraform versions